### PR TITLE
Update the import for math.h so that it finds the correct header.

### DIFF
--- a/iOS/RCTMaterialKit/TickView.m
+++ b/iOS/RCTMaterialKit/TickView.m
@@ -6,7 +6,7 @@
 //  Copyright © 2015年 https://github.com/xinthink. All rights reserved.
 //
 
-#import "math.h"
+#import <math.h>
 
 #import "TickView.h"
 #import "UIColor+MKColor.h"


### PR DESCRIPTION
As written the import causes a react-native project I'm working on to fail to build for iOS.  This change prevents the compiler from looking in other react native packages for math.h and uses the system header instead.